### PR TITLE
Add order, invoice, shipment and credit memo events

### DIFF
--- a/Observer/Cache/BaseObserver.php
+++ b/Observer/Cache/BaseObserver.php
@@ -1,0 +1,17 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Cache;
+
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        $this->eventEmitter->send($this->getFullEventName(), []);
+    }
+}

--- a/Observer/Cache/FlushAll.php
+++ b/Observer/Cache/FlushAll.php
@@ -1,17 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cache;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-
 class FlushAll extends BaseObserver
 {
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $this->eventEmitter->send($this->getFullEventName(), []);
-    }
+
 }

--- a/Observer/Cache/FlushCatalogImages.php
+++ b/Observer/Cache/FlushCatalogImages.php
@@ -1,17 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cache;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-
 class FlushCatalogImages extends BaseObserver
 {
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $this->eventEmitter->send($this->getFullEventName(), []);
-    }
+
 }

--- a/Observer/Cache/FlushMedia.php
+++ b/Observer/Cache/FlushMedia.php
@@ -1,17 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cache;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-
 class FlushMedia extends BaseObserver
 {
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $this->eventEmitter->send($this->getFullEventName(), []);
-    }
+
 }

--- a/Observer/Cache/FlushStaticFiles.php
+++ b/Observer/Cache/FlushStaticFiles.php
@@ -1,17 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cache;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-
 class FlushStaticFiles extends BaseObserver
 {
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $this->eventEmitter->send($this->getFullEventName(), []);
-    }
+
 }

--- a/Observer/Cache/FlushSystem.php
+++ b/Observer/Cache/FlushSystem.php
@@ -1,17 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cache;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-
 class FlushSystem extends BaseObserver
 {
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $this->eventEmitter->send($this->getFullEventName(), []);
-    }
+
 }

--- a/Observer/Cart/BaseObserver.php
+++ b/Observer/Cart/BaseObserver.php
@@ -1,0 +1,14 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Cart;
+
+use Bitbull\AWSEventBridge\Api\Service\ConfigInterface;
+use Bitbull\AWSEventBridge\Api\Service\LoggerInterface;
+use Bitbull\AWSEventBridge\Model\Service\EventEmitter;
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+
+}

--- a/Observer/Cart/ProductAdded.php
+++ b/Observer/Cart/ProductAdded.php
@@ -1,7 +1,6 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cart;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
 use Magento\Framework\Event\Observer;
 
 class ProductAdded extends BaseObserver

--- a/Observer/Cart/ProductRemoved.php
+++ b/Observer/Cart/ProductRemoved.php
@@ -1,7 +1,6 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cart;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
 use Magento\Framework\Event\Observer;
 
 class ProductRemoved extends BaseObserver

--- a/Observer/Cart/ProductUpdated.php
+++ b/Observer/Cart/ProductUpdated.php
@@ -1,7 +1,6 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cart;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
 use Magento\Framework\Event\Observer;
 
 class ProductUpdated extends BaseObserver
@@ -12,6 +11,7 @@ class ProductUpdated extends BaseObserver
      */
     public function execute(Observer $observer)
     {
+        /** @var \Magento\Quote\Model\Quote\Item[] $items */
         $items = $observer->getCart()->getQuote()->getItems();
         $info = $observer->getInfo()->getData();
 

--- a/Observer/Creditmemo/BaseObserver.php
+++ b/Observer/Creditmemo/BaseObserver.php
@@ -1,0 +1,49 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Creditmemo;
+
+use Bitbull\AWSEventBridge\Api\Service\ConfigInterface;
+use Bitbull\AWSEventBridge\Api\Service\LoggerInterface;
+use Bitbull\AWSEventBridge\Model\Service\EventEmitter;
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var \Magento\Sales\Api\Data\CreditmemoInterface $creditMemo */
+        $creditMemo = $observer->getEvent()->getCreditmemo();
+
+        $this->eventEmitter->send($this->getFullEventName(), $this->getCreditmemoData($creditMemo));
+    }
+
+    /**
+     * Get credit memo data
+     *
+     * @var \Magento\Sales\Api\Data\CreditmemoInterface $creditMemo
+     * @return array
+     */
+    public function getCreditmemoData($creditMemo) {
+        return [
+            'id' => $creditMemo->getIncrementId(),
+            'shipping' => $creditMemo->getShippingAmount(),
+            'tax' => $creditMemo->getTaxAmount(),
+            'total' => $creditMemo->getGrandTotal(),
+            'status' => $creditMemo->getCreditmemoStatus(),
+            'items' => array_map(function ($item) {
+                /** @var \Magento\Sales\Api\Data\CreditmemoItemInterface $item */
+                return [
+                    'sku' => $item->getSku(),
+                    'name' => $item->getName(),
+                    'price' => $item->getPrice(),
+                    'quantity' => $item->getQty(),
+                ];
+            }, $creditMemo->getItems())
+        ];
+    }
+}

--- a/Observer/Creditmemo/Deleted.php
+++ b/Observer/Creditmemo/Deleted.php
@@ -1,0 +1,7 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Creditmemo;
+
+class Deleted extends BaseObserver
+{
+
+}

--- a/Observer/Creditmemo/Refunded.php
+++ b/Observer/Creditmemo/Refunded.php
@@ -1,0 +1,7 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Creditmemo;
+
+class Refunded extends BaseObserver
+{
+
+}

--- a/Observer/Creditmemo/Saved.php
+++ b/Observer/Creditmemo/Saved.php
@@ -1,0 +1,7 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Creditmemo;
+
+class Saved extends BaseObserver
+{
+
+}

--- a/Observer/Cron/BaseObserver.php
+++ b/Observer/Cron/BaseObserver.php
@@ -1,0 +1,38 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Cron;
+
+use Bitbull\AWSEventBridge\Api\Service\ConfigInterface;
+use Bitbull\AWSEventBridge\Api\Service\LoggerInterface;
+use Bitbull\AWSEventBridge\Model\Service\EventEmitter;
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        $job = $observer->getData();
+        $this->eventEmitter->send($this->getFullEventName(), $this->getJobData($job));
+    }
+
+    /**
+     * Get job data
+     *
+     * @var array $job
+     * @return array
+     */
+    public function getJobData($job) {
+        return [
+            'code' => $job['code'],
+            'groupId' => $job['groupId'],
+            'jobConfig' => $job['jobConfig'],
+            'duration' => $job['duration'] ?? null,
+            'error' => $job['error'] ?? null
+        ];
+    }
+}

--- a/Observer/Cron/FinishedError.php
+++ b/Observer/Cron/FinishedError.php
@@ -1,23 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cron;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-
 class FinishedError extends BaseObserver
 {
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $eventData = $observer->getData();
-        $this->eventEmitter->send($this->getFullEventName(), [
-            'code' => $eventData['code'],
-            'groupId' => $eventData['groupId'],
-            'jobConfig' => $eventData['jobConfig'],
-            'error' => $eventData['error']
-        ]);
-    }
+
 }

--- a/Observer/Cron/FinishedSuccess.php
+++ b/Observer/Cron/FinishedSuccess.php
@@ -1,23 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cron;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-
 class FinishedSuccess extends BaseObserver
 {
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $eventData = $observer->getData();
-        $this->eventEmitter->send($this->getFullEventName(), [
-            'code' => $eventData['code'],
-            'groupId' => $eventData['groupId'],
-            'jobConfig' => $eventData['jobConfig'],
-            'duration' => $eventData['duration']
-        ]);
-    }
+
 }

--- a/Observer/Cron/Started.php
+++ b/Observer/Cron/Started.php
@@ -1,22 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Cron;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-
 class Started extends BaseObserver
 {
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $eventData = $observer->getData();
-        $this->eventEmitter->send($this->getFullEventName(), [
-            'code' => $eventData['code'],
-            'groupId' => $eventData['groupId'],
-            'jobConfig' => $eventData['jobConfig']
-        ]);
-    }
+
 }

--- a/Observer/Customer/BaseObserver.php
+++ b/Observer/Customer/BaseObserver.php
@@ -1,0 +1,72 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Customer;
+
+use Bitbull\AWSEventBridge\Api\Service\ConfigInterface;
+use Bitbull\AWSEventBridge\Api\Service\LoggerInterface;
+use Bitbull\AWSEventBridge\Model\Service\EventEmitter;
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+    /**
+     * @var CustomerSession
+     */
+    protected $customerSession;
+
+    /**
+     * LoggedIn constructor.
+     * @param LoggerInterface $logger
+     * @param ConfigInterface $config
+     * @param EventEmitter $eventEmitter
+     * @param CustomerSession $customerSession
+     */
+    public function __construct(LoggerInterface $logger, ConfigInterface $config, EventEmitter $eventEmitter, CustomerSession $customerSession)
+    {
+        parent::__construct($logger, $config, $eventEmitter);
+        $this->customerSession = $customerSession;
+    }
+
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var \Magento\Customer\Model\Data\Customer $customer */
+        $customer = $observer->getEvent()->getCustomer();
+        if ($customer === null) {
+            $customer = $this->customerSession->getCustomer();
+            if ($customer->getId() === null) {
+                $this->logger->warn('No customer data in session, skipping ' . $this->getEventName());
+                return;
+            }
+        }
+
+        $this->eventEmitter->send($this->getFullEventName(), $this->getCustomerData($customer));
+    }
+
+    /**
+     * Get customer data
+     *
+     * @var \Magento\Customer\Model\Data\Customer $customer
+     * @return array
+     */
+    public function getCustomerData($customer) {
+        return [
+            'id' => $customer->getId(),
+            'email' => $customer->getEmail(),
+            'defaultBilling' => $customer->getDefaultBilling(),
+            'defaultShipping' => $customer->getDefaultShipping(),
+            'createdAt' => $customer->getCreatedAt(),
+            'firstName' => $customer->getFirstname(),
+            'gender' => $customer->getGender(),
+            'lastName' => $customer->getLastname(),
+            'middleName' => $customer->getMiddlename(),
+            'prefix' => $customer->getPrefix(),
+            'suffix' => $customer->getSuffix(),
+            'addresses' => $customer->getAddresses(),
+        ];
+    }
+}

--- a/Observer/Customer/LoggedIn.php
+++ b/Observer/Customer/LoggedIn.php
@@ -1,47 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Customer;
 
-use Bitbull\AWSEventBridge\Api\Service\ConfigInterface;
-use Bitbull\AWSEventBridge\Api\Service\LoggerInterface;
-use Bitbull\AWSEventBridge\Model\Service\EventEmitter;
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Customer\Model\Session as CustomerSession;
-use Magento\Framework\Event\Observer;
-
 class LoggedIn extends BaseObserver
 {
-    /**
-     * @var CustomerSession
-     */
-    protected $customerSession;
 
-    /**
-     * LoggedIn constructor.
-     * @param LoggerInterface $logger
-     * @param ConfigInterface $config
-     * @param EventEmitter $eventEmitter
-     * @param CustomerSession $customerSession
-     */
-    public function __construct(LoggerInterface $logger, ConfigInterface $config, EventEmitter $eventEmitter, CustomerSession $customerSession)
-    {
-        parent::__construct($logger, $config, $eventEmitter);
-        $this->customerSession = $customerSession;
-    }
-
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $currentCustomerUser = $this->customerSession->getCustomer();
-        if ($currentCustomerUser->getId() !== null) {
-            $this->eventEmitter->send($this->getFullEventName(), [
-                'id' => $currentCustomerUser->getId(),
-                'email' => $currentCustomerUser->getEmail()
-            ]);
-        } else {
-            $this->logger->warn('No customer data in session, skipping ' . $this->getEventName());
-        }
-    }
 }

--- a/Observer/Customer/LoggedOut.php
+++ b/Observer/Customer/LoggedOut.php
@@ -1,47 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Customer;
 
-use Bitbull\AWSEventBridge\Api\Service\ConfigInterface;
-use Bitbull\AWSEventBridge\Api\Service\LoggerInterface;
-use Bitbull\AWSEventBridge\Model\Service\EventEmitter;
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Customer\Model\Session as CustomerSession;
-use Magento\Framework\Event\Observer;
-use \Magento\Backend\Model\Auth\Session as AuthSession;
-
 class LoggedOut extends BaseObserver
 {
-    /**
-     * @var CustomerSession
-     */
-    protected $customerSession;
 
-    /**
-     * LoggedIn constructor.
-     * @param LoggerInterface $logger
-     * @param ConfigInterface $config
-     * @param EventEmitter $eventEmitter
-     * @param CustomerSession $customerSession
-     */
-    public function __construct(LoggerInterface $logger, ConfigInterface $config, EventEmitter $eventEmitter, CustomerSession $customerSession)
-    {
-        parent::__construct($logger, $config, $eventEmitter);
-        $this->customerSession = $customerSession;
-    }
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $currentCustomerUser = $this->customerSession->getCustomer();
-        if ($currentCustomerUser->getId() !== null) {
-            $this->eventEmitter->send($this->getFullEventName(), [
-                'id' => $currentCustomerUser->getId(),
-                'email' => $currentCustomerUser->getEmail()
-            ]);
-        } else {
-            $this->logger->warn('No customer data in session, skipping ' . $this->getEventName());
-        }
-    }
 }

--- a/Observer/Customer/LoginFailed.php
+++ b/Observer/Customer/LoginFailed.php
@@ -40,13 +40,16 @@ class LoginFailed extends BaseObserver
         $postData = $observer->getRequest()->getPost();
         $errorMessages = $this->messageManager->getMessages()->getErrors();
 
-        if (count($errorMessages) > 0) {
-            $this->eventEmitter->send($this->getFullEventName(), [
-                'messages' => array_map(function($errorMessage) {
-                    return $errorMessage->getText();
-                }, $errorMessages),
-                'username' => isset($postData['login']) ? $postData['login']['username'] : null
-            ]);
+        if (count($errorMessages) === 0) {
+            $this->logger->warn('No errors found, skipping ' . $this->getEventName());
+            return;
         }
+
+        $this->eventEmitter->send($this->getFullEventName(), [
+            'messages' => array_map(function($errorMessage) {
+                return $errorMessage->getText();
+            }, $errorMessages),
+            'username' => isset($postData['login']) ? $postData['login']['username'] : null
+        ]);
     }
 }

--- a/Observer/Customer/SignedUp.php
+++ b/Observer/Customer/SignedUp.php
@@ -1,34 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Customer;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-
 class SignedUp extends BaseObserver
 {
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $customer = $observer->getEvent()->getCustomer();
-        if ($customer === null) {
-            return;
-        }
-        $this->eventEmitter->send($this->getFullEventName(), [
-            'defaultBilling' => $customer->getDefaultBilling(),
-            'defaultShipping' => $customer->getDefaultShipping(),
-            'createdAt' => $customer->getCreatedAt(),
-            'email' => $customer->getEmail(),
-            'firstname' => $customer->getFirstname(),
-            'gender' => $customer->getGender(),
-            'id' => $customer->getId(),
-            'lastname' => $customer->getLastname(),
-            'middlename' => $customer->getMiddlename(),
-            'prefix' => $customer->getPrefix(),
-            'suffix' => $customer->getSuffix(),
-            'addresses' => $customer->getAddresses(),
-        ]);
-    }
+
 }

--- a/Observer/Customer/SignedUpFailed.php
+++ b/Observer/Customer/SignedUpFailed.php
@@ -40,15 +40,18 @@ class SignedUpFailed extends BaseObserver
         $postData = $observer->getRequest()->getPost();
         $errorMessages = $this->messageManager->getMessages()->getErrors();
 
-        if (count($errorMessages) > 0) {
-            $this->eventEmitter->send($this->getFullEventName(), [
-                'messages' => array_map(function($errorMessage) {
-                    return $errorMessage->getText();
-                }, $errorMessages),
-                'firstname' => $postData['firstname'] ?? null,
-                'lastname' => $postData['lastname'] ?? null,
-                'email' => $postData['email'] ?? null,
-            ]);
+        if (count($errorMessages) === 0) {
+            $this->logger->warn('No errors found, skipping ' . $this->getEventName());
+            return;
         }
+
+        $this->eventEmitter->send($this->getFullEventName(), [
+            'messages' => array_map(function($errorMessage) {
+                return $errorMessage->getText();
+            }, $errorMessages),
+            'firstname' => $postData['firstname'] ?? null,
+            'lastname' => $postData['lastname'] ?? null,
+            'email' => $postData['email'] ?? null,
+        ]);
     }
 }

--- a/Observer/Invoice/BaseObserver.php
+++ b/Observer/Invoice/BaseObserver.php
@@ -1,0 +1,45 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Invoice;
+
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var \Magento\Sales\Api\Data\InvoiceInterface $invoice */
+        $invoice = $observer->getEvent()->getInvoice();
+
+        $this->eventEmitter->send($this->getFullEventName(), $this->getInvoiceData($invoice));
+    }
+
+    /**
+     * Get invoice data
+     *
+     * @var \Magento\Sales\Api\Data\InvoiceInterface $invoice
+     * @return array
+     */
+    public function getInvoiceData($invoice) {
+        return [
+            'id' => $invoice->getIncrementId(),
+            'orderId' => $invoice->getOrderId(),
+            'shipping' => $invoice->getShippingAmount(),
+            'tax' => $invoice->getTaxAmount(),
+            'total' => $invoice->getGrandTotal(),
+            'items' => array_map(function ($item) {
+                /** @var \Magento\Sales\Api\Data\InvoiceItemInterface $item */
+                return [
+                    'sku' => $item->getSku(),
+                    'name' => $item->getName(),
+                    'price' => $item->getPrice(),
+                    'quantity' => $item->getQty(),
+                ];
+            }, $invoice->getItems())
+        ];
+    }
+}

--- a/Observer/Invoice/Deleted.php
+++ b/Observer/Invoice/Deleted.php
@@ -1,0 +1,7 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Invoice;
+
+class Deleted extends BaseObserver
+{
+
+}

--- a/Observer/Invoice/Payed.php
+++ b/Observer/Invoice/Payed.php
@@ -1,0 +1,7 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Invoice;
+
+class Payed extends BaseObserver
+{
+
+}

--- a/Observer/Invoice/Saved.php
+++ b/Observer/Invoice/Saved.php
@@ -1,0 +1,7 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Invoice;
+
+class Saved extends BaseObserver
+{
+
+}

--- a/Observer/Newsletter/BaseObserver.php
+++ b/Observer/Newsletter/BaseObserver.php
@@ -1,0 +1,35 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Newsletter;
+
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var \Magento\Newsletter\Model\Subscriber $subscriber */
+        $subscriber = $observer->getEvent()->getSubscriber();
+
+        $this->eventEmitter->send($this->getFullEventName(), $this->getSubscriberData($subscriber));
+    }
+
+    /**
+     * Get subscriber data
+     *
+     * @var \Magento\Newsletter\Model\Subscriber $subscriber
+     * @return array
+     */
+    public function getSubscriberData($subscriber) {
+        return [
+            'email' => $subscriber->getEmail(),
+            'unsubscriptionLink' => $subscriber->getUnsubscriptionLink(),
+            'code' => $subscriber->getCode(),
+            'status' => $subscriber->getStatus()
+        ];
+    }
+}

--- a/Observer/Newsletter/SubscriptionChanged.php
+++ b/Observer/Newsletter/SubscriptionChanged.php
@@ -1,7 +1,6 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Newsletter;
 
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
 use Magento\Framework\Event\Observer;
 
 class SubscriptionChanged extends BaseObserver
@@ -12,12 +11,11 @@ class SubscriptionChanged extends BaseObserver
      */
     public function execute(Observer $observer)
     {
+        /** @var \Magento\Newsletter\Model\Subscriber $subscriber */
         $subscriber = $observer->getEvent()->getSubscriber();
         if ($subscriber->isStatusChanged() === false) {
             return;
         }
-        $this->eventEmitter->send($this->getFullEventName(), [
-            'status' => $subscriber->isSubscribed()
-        ]);
+        $this->eventEmitter->send($this->getFullEventName(), $this->getSubscriberData($subscriber));
     }
 }

--- a/Observer/Order/BaseObserver.php
+++ b/Observer/Order/BaseObserver.php
@@ -1,0 +1,47 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Order;
+
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var \Magento\Sales\Api\Data\OrderInterface $order */
+        $order = $observer->getEvent()->getOrder();
+
+        $this->eventEmitter->send($this->getFullEventName(), $this->getOrderData($order));
+    }
+
+    /**
+     * Get order data
+     *
+     * @var \Magento\Sales\Api\Data\OrderInterface $order
+     * @return array
+     */
+    public function getOrderData($order) {
+        return [
+            'id' => $order->getIncrementId(),
+            'status' => $order->getStatus(),
+            'shipping' => $order->getShippingAmount(),
+            'coupon' => $order->getCouponCode(),
+            'tax' => $order->getTaxAmount(),
+            'total' => $order->getGrandTotal(),
+            'items' => array_map(function ($item) {
+
+                /** @var \Magento\Sales\Api\Data\OrderItemInterface $item */
+                return [
+                    'sku' => $item->getSku(),
+                    'name' => $item->getName(),
+                    'price' => $item->getPrice(),
+                    'qty' => $item->getQtyOrdered(),
+                ];
+            }, $order->getItems())
+        ];
+    }
+}

--- a/Observer/Order/Canceled.php
+++ b/Observer/Order/Canceled.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Order;
 
-class Placed extends BaseObserver
+class Canceled extends BaseObserver
 {
 
 }

--- a/Observer/Order/Deleted.php
+++ b/Observer/Order/Deleted.php
@@ -1,7 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\Order;
 
-class Placed extends BaseObserver
+class Deleted extends BaseObserver
 {
 
 }

--- a/Observer/Order/Saved.php
+++ b/Observer/Order/Saved.php
@@ -1,0 +1,21 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Order;
+
+use Magento\Framework\Event\Observer;
+
+class Saved extends BaseObserver
+{
+    /**
+     * @inheritDoc
+     */
+    public function execute(Observer $observer) {
+        /** @var \Magento\Sales\Api\Data\OrderInterface $order */
+        $order = $observer->getEvent()->getOrder();
+
+        if ($order->isObjectNew()) {
+            $this->eventEmitter->send($this->getScopeName() . 'Created', $this->getOrderData($order));
+        } else {
+            $this->eventEmitter->send($this->getScopeName(). 'Updated', $this->getOrderData($order));
+        }
+    }
+}

--- a/Observer/Shipment/BaseObserver.php
+++ b/Observer/Shipment/BaseObserver.php
@@ -1,0 +1,45 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Shipment;
+
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var \Magento\Sales\Api\Data\ShipmentInterface $shipment */
+        $shipment = $observer->getEvent()->getShipment();
+
+        $this->eventEmitter->send($this->getFullEventName(), $this->getShipmentData($shipment));
+    }
+
+    /**
+     * Get order data
+     *
+     * @var \Magento\Sales\Api\Data\ShipmentInterface $shipment
+     * @return array
+     */
+    public function getShipmentData($shipment) {
+        return [
+            'id' => $shipment->getIncrementId(),
+            'comments' => $shipment->getComments(),
+            'qty' => $shipment->getTotalQty(),
+            'weight' => $shipment->getTotalWeight(),
+            'items' => array_map(function ($item) {
+
+                /** @var \Magento\Sales\Api\Data\ShipmentItemInterface $item */
+                return [
+                    'sku' => $item->getSku(),
+                    'name' => $item->getName(),
+                    'price' => $item->getPrice(),
+                    'qty' => $item->getQty()
+                ];
+            }, $shipment->getItems()->getItems()) // not a typo, first getItems return a collection, not an array
+        ];
+    }
+}

--- a/Observer/Shipment/Deleted.php
+++ b/Observer/Shipment/Deleted.php
@@ -1,0 +1,7 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Shipment;
+
+class Deleted extends BaseObserver
+{
+
+}

--- a/Observer/Shipment/Saved.php
+++ b/Observer/Shipment/Saved.php
@@ -1,0 +1,7 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\Shipment;
+
+class Saved extends BaseObserver
+{
+
+}

--- a/Observer/User/BaseObserver.php
+++ b/Observer/User/BaseObserver.php
@@ -1,0 +1,64 @@
+<?php
+namespace Bitbull\AWSEventBridge\Observer\User;
+
+use Bitbull\AWSEventBridge\Api\Service\ConfigInterface;
+use Bitbull\AWSEventBridge\Api\Service\LoggerInterface;
+use Bitbull\AWSEventBridge\Model\Service\EventEmitter;
+use Bitbull\AWSEventBridge\Observer\BaseObserver as ParentBaseObserver;
+use Magento\Backend\Model\Auth\Session as BackendUserSession;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Event\Observer;
+
+abstract class BaseObserver extends ParentBaseObserver
+{
+    /**
+     * @var BackendUserSession
+     */
+    protected $backendUserSession;
+
+    /**
+     * LoggedIn constructor.
+     * @param LoggerInterface $logger
+     * @param ConfigInterface $config
+     * @param EventEmitter $eventEmitter
+     * @param BackendUserSession $backendUserSession
+     */
+    public function __construct(LoggerInterface $logger, ConfigInterface $config, EventEmitter $eventEmitter, BackendUserSession $backendUserSession)
+    {
+        parent::__construct($logger, $config, $eventEmitter);
+        $this->backendUserSession = $backendUserSession;
+    }
+
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var \Magento\Customer\Model\Data\Customer $user */
+        $user = $observer->getEvent()->getUser();
+        if ($user === null) {
+            $user = $this->backendUserSession->getUser();
+            if ($user->getId() === null) {
+                $this->logger->warn('No admin user data in session, skipping ' . $this->getEventName());
+                return;
+            }
+        }
+
+        $this->eventEmitter->send($this->getFullEventName(), $this->getUserData($user));
+    }
+
+    /**
+     * Get user data
+     *
+     * @var \Magento\User\Model\User $user
+     * @return array
+     */
+    public function getUserData($user) {
+        return [
+            'id' => $user->getId(),
+            'username' => $user->getUserName(),
+            'email' => $user->getEmail()
+        ];
+    }
+}

--- a/Observer/User/LoggedIn.php
+++ b/Observer/User/LoggedIn.php
@@ -1,48 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\User;
 
-use Bitbull\AWSEventBridge\Api\Service\ConfigInterface;
-use Bitbull\AWSEventBridge\Api\Service\LoggerInterface;
-use Bitbull\AWSEventBridge\Model\Service\EventEmitter;
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Framework\Event\Observer;
-use Magento\Backend\Model\Auth\Session as BackendUserSession;
-
 class LoggedIn extends BaseObserver
 {
-    /**
-     * @var BackendUserSession
-     */
-    protected $backendUserSession;
 
-    /**
-     * LoggedIn constructor.
-     * @param LoggerInterface $logger
-     * @param ConfigInterface $config
-     * @param EventEmitter $eventEmitter
-     * @param BackendUserSession $backendUserSession
-     */
-    public function __construct(LoggerInterface $logger, ConfigInterface $config, EventEmitter $eventEmitter, BackendUserSession $backendUserSession)
-    {
-        parent::__construct($logger, $config, $eventEmitter);
-        $this->backendUserSession = $backendUserSession;
-    }
-
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $currentAdminUser = $this->backendUserSession->getUser();
-        if ($currentAdminUser !== null) {
-            $this->eventEmitter->send($this->getFullEventName(), [
-                'id' => $currentAdminUser->getId(),
-                'username' => $currentAdminUser->getUserName(),
-                'email' => $currentAdminUser->getEmail()
-            ]);
-        } else {
-            $this->logger->warn('No admin user data in session, skipping ' . $this->getEventName());
-        }
-    }
 }

--- a/Observer/User/LoggedOut.php
+++ b/Observer/User/LoggedOut.php
@@ -1,48 +1,7 @@
 <?php
 namespace Bitbull\AWSEventBridge\Observer\User;
 
-use Bitbull\AWSEventBridge\Api\Service\ConfigInterface;
-use Bitbull\AWSEventBridge\Api\Service\LoggerInterface;
-use Bitbull\AWSEventBridge\Model\Service\EventEmitter;
-use Bitbull\AWSEventBridge\Observer\BaseObserver;
-use Magento\Backend\Model\Auth\Session as BackendUserSession;
-use Magento\Framework\Event\Observer;
-
 class LoggedOut extends BaseObserver
 {
-    /**
-     * @var BackendUserSession
-     */
-    protected $backendUserSession;
 
-    /**
-     * LoggedIn constructor.
-     * @param LoggerInterface $logger
-     * @param ConfigInterface $config
-     * @param EventEmitter $eventEmitter
-     * @param BackendUserSession $backendUserSession
-     */
-    public function __construct(LoggerInterface $logger, ConfigInterface $config, EventEmitter $eventEmitter, BackendUserSession $backendUserSession)
-    {
-        parent::__construct($logger, $config, $eventEmitter);
-        $this->backendUserSession = $backendUserSession;
-    }
-
-    /**
-     * @param Observer $observer
-     * @return void
-     */
-    public function execute(Observer $observer)
-    {
-        $currentAdminUser = $this->backendUserSession->getUser();
-        if ($currentAdminUser !== null) {
-            $this->eventEmitter->send($this->getFullEventName(), [
-                'id' => $currentAdminUser->getId(),
-                'username' => $currentAdminUser->getUserName(),
-                'email' => $currentAdminUser->getEmail()
-            ]);
-        } else {
-            $this->logger->warn('No admin user data in session, skipping ' . $this->getEventName());
-        }
-    }
 }

--- a/README.md
+++ b/README.md
@@ -174,65 +174,110 @@ Here a list of supported events that can be enabled:
 #### Cart events
 
 `CartProductAdded`
-A product is added to cart by a customer
+A product is added to cart by a customer.
 
 `CartProductUpdated`
-A cart is updated by a customer
+A cart is updated by a customer.
 
 `CartProductRemoved`
-A product is removed from cart by a customer
+A product is removed from cart by a customer.
 
 #### Admin user events
 
 `UserLoggedIn`
-An admin user logged in
+An admin user logged in.
 
 `UserLoggedOut`
-An admin user logged out
+An admin user logged out.
 
 `UserLoginFailed`
-An admin user failed login
+An admin user failed login.
 
 #### Customers events
 
 `CustomerLoggedIn`
-A customer user logged in
+A customer user logged in.
 
 `CustomerLoggedOut`
-A customer user logged out
+A customer user logged out.
 
 `CustomerLoginFailed`
-A customer user failed login
+A customer user failed login.
 
 `CustomerSignedUp`
-A customer user sign up
+A customer user sign up.
 
 `CustomerSignedUpFailed`
-A customer user failed sign up
+A customer user failed sign up.
 
 #### Newsletter events
 
 `NewsletterSubscriptionChanged`
-A customer user change newsletter subscription preference
+A customer user change newsletter subscription preference.
 
 #### Order events
 
 `OrderPlaced`
-A customer place a new order
+A customer place a new order.
+
+`OrderPlaced`
+A customer place a new order.
+
+`OrderCreated` / `OrderUpdated`
+An order was saved.
+
+`OrderCanceled`
+An order was canceled.
+
+`OrderDeleted`
+An order was deleted.
+
+#### Invoice events
+
+`InvoiceCreated` / `InvoiceUpdated`
+An invoice was saved.
+
+`InvoicePayed`
+An invoice was payed.
+
+`InvoiceRegistered`
+An invoice was registered.
+
+`OrderDeleted`
+An invoice was deleted.
+
+#### Credit Memo events
+
+`CreditmemoCreated` / `CreditmemoUpdated`
+A credit memo was saved.
+
+`CreditmemoRefunded`
+A credit memo was refunded.
+
+`CreditmemoDeleted`
+A credit memo was deleted.
+
+#### Shipment events
+
+`ShipmentCreated` / `ShipmentUpdated`
+A shipment was saved.
+
+`ShipmentDeleted`
+A shipment was deleted.
 
 #### Cache events
 
 `CacheFlushAll`
-An admin user flush the cache
+An admin user flush the cache.
 
 `CacheFlushSystem`
-An admin user flush system cache
+An admin user flush system cache.
 
 `CacheFlushCatalogImages`
-An admin user flush catalog images cache
+An admin user flush catalog images cache.
 
 `CacheFlushMedia`
-An admin user flush media cache
+An admin user flush media cache.
 
 `CacheFlushStaticFiles`
-An admin user flush static files cache
+An admin user flush static files cache.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -45,11 +45,11 @@
                 </field>
                 <field id="source" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Event source name</label>
-                    <comment><![CDATA[If empty will be used the store's domain name]]></comment>
+                    <comment><![CDATA[If empty will be used the store's domain name.]]></comment>
                 </field>
                 <field id="event_bus" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Event bus name</label>
-                    <comment><![CDATA[The event bus to associate with event rules. If you omit this, the default event bus is used]]></comment>
+                    <comment><![CDATA[The event bus to associate with event rules. If you omit this, the default event bus is used.]]></comment>
                     <depends>
                         <field id="cloudwatch_event_fallback">0</field>
                     </depends>
@@ -57,12 +57,12 @@
                 <field id="cloudwatch_event_fallback" translate="label" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CloudWatch Events fallback</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment><![CDATA[Use AWS CloudWatch Events service instead of AWS EventBridge]]></comment>
+                    <comment><![CDATA[Use AWS CloudWatch Events service instead of AWS EventBridge.]]></comment>
                 </field>
                 <field id="tracking" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Enable tracking</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                    <comment><![CDATA[Enable source event tracking]]></comment>
+                    <comment><![CDATA[Enable source event tracking.]]></comment>
                 </field>
                 <field id="debug_mode" translate="label" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Debug mode</label>
@@ -79,17 +79,17 @@
                 <label>Cart events</label>
                 <field id="product_added" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CartProductAdded</label>
-                    <comment><![CDATA[A product is added to cart by a customer]]></comment>
+                    <comment><![CDATA[A product is added to cart by a customer.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="product_updated" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CartProductUpdated</label>
-                    <comment><![CDATA[A cart is updated by a customer]]></comment>
+                    <comment><![CDATA[A cart is updated by a customer.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="product_removed" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CartProductRemoved</label>
-                    <comment><![CDATA[A product is removed from cart by a customer]]></comment>
+                    <comment><![CDATA[A product is removed from cart by a customer.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
@@ -97,17 +97,17 @@
                 <label>Admin user events</label>
                 <field id="logged_in" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>UserLoggedIn</label>
-                    <comment><![CDATA[An admin user logged in]]></comment>
+                    <comment><![CDATA[An admin user logged in.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="logged_out" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>UserLoggedOut</label>
-                    <comment><![CDATA[An admin user logged out]]></comment>
+                    <comment><![CDATA[An admin user logged out.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="login_failed" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>UserLoginFailed</label>
-                    <comment><![CDATA[An admin user failed login]]></comment>
+                    <comment><![CDATA[An admin user failed login.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
@@ -115,27 +115,27 @@
                 <label>Customers events</label>
                 <field id="logged_in" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CustomerLoggedIn</label>
-                    <comment><![CDATA[A customer user logged in]]></comment>
+                    <comment><![CDATA[A customer user logged in.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="logged_out" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CustomerLoggedOut</label>
-                    <comment><![CDATA[A customer user logged out]]></comment>
+                    <comment><![CDATA[A customer user logged out.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="login_failed" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CustomerLoginFailed</label>
-                    <comment><![CDATA[A customer user failed login]]></comment>
+                    <comment><![CDATA[A customer user failed login.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="signed_up" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CustomerSignedUp</label>
-                    <comment><![CDATA[A customer user sign up]]></comment>
+                    <comment><![CDATA[A customer user sign up.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="signed_up_failed" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CustomerSignedUpFailed</label>
-                    <comment><![CDATA[A customer user failed sign up]]></comment>
+                    <comment><![CDATA[A customer user failed sign up.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
@@ -143,7 +143,7 @@
                 <label>Newsletter events</label>
                 <field id="subscription_changed" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>NewsletterSubscriptionChanged</label>
-                    <comment><![CDATA[A customer user change newsletter subscription preference]]></comment>
+                    <comment><![CDATA[A customer user change newsletter subscription preference.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
@@ -151,7 +151,7 @@
                 <label>Order events</label>
                 <field id="placed" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>OrderPlaced</label>
-                    <comment><![CDATA[A customer place a new order]]></comment>
+                    <comment><![CDATA[A customer place a new order.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="saved" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -228,27 +228,27 @@
                 <label>Cache events</label>
                 <field id="flush_all" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CacheFlushAll</label>
-                    <comment><![CDATA[An admin user flush the cache]]></comment>
+                    <comment><![CDATA[An admin user flush the cache.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="flush_system" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CacheFlushSystem</label>
-                    <comment><![CDATA[An admin user flush system cache]]></comment>
+                    <comment><![CDATA[An admin user flush system cache.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="flush_catalog_images" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CacheFlushCatalogImages</label>
-                    <comment><![CDATA[An admin user flush catalog images cache]]></comment>
+                    <comment><![CDATA[An admin user flush catalog images cache.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="flush_media" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CacheFlushMedia</label>
-                    <comment><![CDATA[An admin user flush media cache]]></comment>
+                    <comment><![CDATA[An admin user flush media cache.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="flush_static_files" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CacheFlushStaticFiles</label>
-                    <comment><![CDATA[An admin user flush static files cache]]></comment>
+                    <comment><![CDATA[An admin user flush static files cache.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
@@ -256,17 +256,17 @@
                 <label>Cron events</label>
                 <field id="started" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CronStarted</label>
-                    <comment><![CDATA[A cron job started]]></comment>
+                    <comment><![CDATA[A cron job started.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="finished_error" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CronFinishedError</label>
-                    <comment><![CDATA[A cron job finished with errors]]></comment>
+                    <comment><![CDATA[A cron job finished with errors.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
                 <field id="finished_success" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CronFinishedSuccess</label>
-                    <comment><![CDATA[A cron job finished successfully]]></comment>
+                    <comment><![CDATA[A cron job finished successfully.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -123,17 +123,17 @@
                     <comment><![CDATA[A customer user logged out]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="customer_login_failed" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="login_failed" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CustomerLoginFailed</label>
                     <comment><![CDATA[A customer user failed login]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="customer_signed_up" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="signed_up" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CustomerSignedUp</label>
                     <comment><![CDATA[A customer user sign up]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
-                <field id="customer_signed_up_failed" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="signed_up_failed" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CustomerSignedUpFailed</label>
                     <comment><![CDATA[A customer user failed sign up]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
@@ -147,15 +147,84 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
-            <group id="events_order" translate="label" type="text" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="events_order" translate="label" type="text" sortOrder="7" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Order events</label>
                 <field id="placed" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>OrderPlaced</label>
                     <comment><![CDATA[A customer place a new order]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="saved" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>OrderCreated / OrderUpdated</label>
+                    <comment><![CDATA[An order was saved.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="canceled" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>OrderCanceled</label>
+                    <comment><![CDATA[An order was canceled.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="deleted" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>OrderDeleted</label>
+                    <comment><![CDATA[An order was deleted.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
-            <group id="events_cache" translate="label" type="text" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="events_invoice" translate="label" type="text" sortOrder="8" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Invoice events</label>
+                <field id="saved" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>InvoiceCreated / InvoiceUpdated</label>
+                    <comment><![CDATA[An invoice was saved.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="payed" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>InvoicePayed</label>
+                    <comment><![CDATA[An invoice was payed.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="registered" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>InvoiceRegistered</label>
+                    <comment><![CDATA[An invoice was registered.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="deleted" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>OrderDeleted</label>
+                    <comment><![CDATA[An invoice was deleted.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+            <group id="events_creditmemo" translate="label" type="text" sortOrder="9" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Credit Memo events</label>
+                <field id="saved" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>CreditmemoCreated / CreditmemoUpdated</label>
+                    <comment><![CDATA[A credit memo was saved.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="refunded" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>CreditmemoRefunded</label>
+                    <comment><![CDATA[A credit memo was refunded.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="deleted" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>CreditmemoDeleted</label>
+                    <comment><![CDATA[A credit memo was deleted.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+            <group id="events_shipment" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Shipment events</label>
+                <field id="saved" type="select" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>ShipmentCreated / ShipmentUpdated</label>
+                    <comment><![CDATA[A shipment was saved.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="deleted" type="select" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>ShipmentDeleted</label>
+                    <comment><![CDATA[A shipment was deleted.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
+            <group id="events_cache" translate="label" type="text" sortOrder="11" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Cache events</label>
                 <field id="flush_all" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CacheFlushAll</label>
@@ -183,7 +252,7 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
-            <group id="events_cron" translate="label" type="text" sortOrder="7" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="events_cron" translate="label" type="text" sortOrder="12" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Cron events</label>
                 <field id="started" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>CronStarted</label>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -104,6 +104,51 @@
     <type name="Bitbull\AWSEventBridge\Observer\Order\Placed">
         <plugin name="AroundEventOrderPlaced" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
     </type>
+    <type name="Bitbull\AWSEventBridge\Observer\Order\Saved">
+        <plugin name="AroundEventOrderSaved" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+    <type name="Bitbull\AWSEventBridge\Observer\Order\Canceled">
+        <plugin name="AroundEventOrderCanceled" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+    <type name="Bitbull\AWSEventBridge\Observer\Order\Deleted">
+        <plugin name="AroundEventOrderDeleted" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+
+    <!-- Observers invoice -->
+
+    <type name="Bitbull\AWSEventBridge\Observer\Invoice\Saved">
+        <plugin name="AroundEventInvoiceSaved" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+    <type name="Bitbull\AWSEventBridge\Observer\Invoice\Registered">
+        <plugin name="AroundEventInvoiceRegistered" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+    <type name="Bitbull\AWSEventBridge\Observer\Invoice\Payed">
+        <plugin name="AroundEventInvoicePayed" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+    <type name="Bitbull\AWSEventBridge\Observer\Invoice\Deleted">
+        <plugin name="AroundEventInvoiceDeleted" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+
+    <!-- Observers creditmemo -->
+
+    <type name="Bitbull\AWSEventBridge\Observer\Creditmemo\Saved">
+        <plugin name="AroundEventInvoiceDeleted" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+    <type name="Bitbull\AWSEventBridge\Observer\Creditmemo\Refunded">
+        <plugin name="AroundEventInvoiceDeleted" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+    <type name="Bitbull\AWSEventBridge\Observer\Creditmemo\Deleted">
+        <plugin name="AroundEventInvoiceDeleted" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+
+    <!-- Observers shipment -->
+
+    <type name="Bitbull\AWSEventBridge\Observer\Shipment\Saved">
+        <plugin name="AroundEventInvoiceDeleted" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
+    <type name="Bitbull\AWSEventBridge\Observer\Shipment\Deleted">
+        <plugin name="AroundEventInvoiceDeleted" type="Bitbull\AWSEventBridge\Plugin\Observer\CheckConfigFlag" sortOrder="1" disabled="false"/>
+    </type>
 
     <!-- Observers cache -->
 

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,10 +1,55 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
 
-    <!-- Checkout -->
+    <!-- Order -->
 
     <event name="sales_order_place_after">
         <observer name="awseventbridge_order_placed" instance="Bitbull\AWSEventBridge\Observer\Order\Placed"/>
+    </event>
+    <event name="sales_order_save_after">
+        <observer name="awseventbridge_order_saved" instance="Bitbull\AWSEventBridge\Observer\Order\Saved"/>
+    </event>
+    <event name="order_cancel_after">
+        <observer name="awseventbridge_order_canceled" instance="Bitbull\AWSEventBridge\Observer\Order\Canceled"/>
+    </event>
+    <event name="sales_order_delete_after">
+        <observer name="awseventbridge_order_deleted" instance="Bitbull\AWSEventBridge\Observer\Order\Deleted"/>
+    </event>
+
+    <!-- Invoice -->
+
+    <event name="sales_order_invoice_save_after">
+        <observer name="awseventbridge_invoice_saved" instance="Bitbull\AWSEventBridge\Observer\Invoice\Saved"/>
+    </event>
+    <event name="sales_order_invoice_register">
+        <observer name="awseventbridge_invoice_registered" instance="Bitbull\AWSEventBridge\Observer\Invoice\Registered"/>
+    </event>
+    <event name="sales_order_invoice_pay">
+        <observer name="awseventbridge_invoice_payed" instance="Bitbull\AWSEventBridge\Observer\Invoice\Payed"/>
+    </event>
+    <event name="sales_order_invoice_delete_after">
+        <observer name="awseventbridge_invoice_deleted" instance="Bitbull\AWSEventBridge\Observer\Invoice\Deleted"/>
+    </event>
+
+    <!-- Creditmemo -->
+
+    <event name="sales_order_creditmemo_save_after">
+        <observer name="awseventbridge_creditmemo_saved" instance="Bitbull\AWSEventBridge\Observer\Creditmemo\Saved"/>
+    </event>
+    <event name="sales_order_creditmemo_refund">
+        <observer name="awseventbridge_creditmemo_refunded" instance="Bitbull\AWSEventBridge\Observer\Creditmemo\Refunded"/>
+    </event>
+    <event name="sales_order_creditmemo_delete_after">
+        <observer name="awseventbridge_creditmemo_deleted" instance="Bitbull\AWSEventBridge\Observer\Creditmemo\Deleted"/>
+    </event>
+
+    <!-- Shipment -->
+
+    <event name="sales_order_shipment_save_after">
+        <observer name="awseventbridge_shipment_saved" instance="Bitbull\AWSEventBridge\Observer\Shipment\Saved"/>
+    </event>
+    <event name="sales_order_shipment_delete_after">
+        <observer name="awseventbridge_shipment_deleted" instance="Bitbull\AWSEventBridge\Observer\Shipment\Deleted"/>
     </event>
 
     <!-- Cache -->


### PR DESCRIPTION
This PR also include a refactoring of data retrieve for model passed to observer event, this will centralize the data aggregation across events (with the same scope).

ref: https://github.com/bitbull-team/magento2-module-awseventbridge/issues/1